### PR TITLE
Add nix package expression and fix editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,8 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = false
-indent_style = tab
+indent_style = space
+indent_size = 4
+
+[*.nix]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+result/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,54 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.callPackage 
+({ python3
+, meson
+, ninja
+, wrapGAppsHook
+, pkg-config
+, gettext
+, appstream-glib
+, desktop-file-utils
+, gobject-introspection
+, libhandy
+, gtk3
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "spotipyne";
+  version = "0.0";
+
+  format = "other";
+
+  src = builtins.filterSource
+    (path: type: baseNameOf path != "build") ./.;
+
+  nativeBuildInputs = [ 
+    meson
+    ninja
+    wrapGAppsHook 
+    pkg-config
+    gettext
+    appstream-glib
+    desktop-file-utils
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    libhandy
+    gtk3
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    pyxdg
+    spotipy
+  ];
+
+  preBuild = ''
+    substituteInPlace ../meson.build \
+      --replace "meson.add_install_script('build-aux/meson/postinstall.py')" ""
+  '';
+
+  strictDeps = false;
+
+}) { }


### PR DESCRIPTION
I was able to simplify the nix expression and fit it in one file, so it would probably be better as a default.nix in the root. If you have nix installed you can build the code with `nix-build` or `nix build -f default.nix`(old ui vs new ui for nix). This is generally pretty useful to make sure the project builds correctly. And it will help people on nixos work on spotipyne(me). I can move it if into a nix folder, if that's still preferred. 

Also the `.editorconfig` didn't actually match the code style and it kept messing with vim. The python code is using 4 spaces, but the editorconfig said to use hard tabs. So I also included that fix for the python and nix code in this PR, its fairly simple.