### PR TITLE
Ensure that action names are valid

### DIFF
--- a/src/simpleControls.py
+++ b/src/simpleControls.py
@@ -200,10 +200,11 @@ class SimpleControls(Gtk.Revealer):
         self.action_group = Gio.SimpleActionGroup.new()
         for dev in devs:
             dev_name = dev['name']
-            device_action = Gio.SimpleAction(name=dev_name)
+            action_name = dev_name.replace(' ', '_')
+            device_action = Gio.SimpleAction(name=action_name)
             Gio.Application.get_default().add_action(device_action)
             device_action.connect("activate", activate_device, dev['id'])
-            detailed_action = "app." + dev_name
+            detailed_action = "app." + action_name
             self.devices_list_menu.append(dev_name, detailed_action)
 
     def updateSongLabel(self, spotify_playback):


### PR DESCRIPTION
Action names aren't allowed to include spaces in their names, but
as e.g. Amazon allows devices names like "Owner Echo Show".
Therefore ensure that there is no whitespace included.

Fixes: https://github.com/dann-merlin/Spotipyne/issues/17